### PR TITLE
[v1.1] Add support for errors-in-variables

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,9 @@
 extends: 'eslint-config-cheminfo'
 parserOptions:
   sourceType: module
+
+rules:
+  handle-callback-err: 0
+  arrow-parens: 0
+  space-in-parens: 0
+  padded-blocks: 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-levenberg-marquardt",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Curve fitting method in javascript",
   "main": "./lib/index.js",
   "files": [
@@ -47,6 +47,10 @@
     "rollup": "^0.55.5"
   },
   "dependencies": {
-    "ml-matrix": "^5.0.1"
+    "ml-matrix": "^5.0.1",
+    "norm-dist": "^2.0.1"
+  },
+  "jest": {
+    "testURL": "http://localhost"
   }
 }

--- a/src/__tests__/curve.js
+++ b/src/__tests__/curve.js
@@ -32,8 +32,8 @@ test('bennet5 problem', () => {
     damping: 0.00001,
     maxIterations: 1000,
     errorTolerance: 1e-3,
-    maxBound: [11, 11, 11],
-    minBound: [1, 1, 1],
+    maxValues: [11, 11, 11],
+    minValues: [1, 1, 1],
     initialValues: [3.5, 3.8, 4]
   };
 
@@ -50,7 +50,7 @@ test('fourParamEq', () => {
 
   expect(levenbergMarquardt(data, fourParamEq, options)).toBeDeepCloseTo({
     iterations: 200,
-    parameterError: 374.6448,
+    residuals: 16398.0009,
     parameterValues: [-16.7697, 43.4549, 1018.8938, -4.3514]
   }, 3);
 });
@@ -64,7 +64,7 @@ test('error is NaN', () => {
 
   expect(levenbergMarquardt(data, fourParamEq, options)).toBeDeepCloseTo({
     iterations: 0,
-    parameterError: NaN,
+    residuals: NaN,
     parameterValues: [-64.298, 117.4022, -47.0851, -0.06148]
   }, 3);
 });

--- a/src/__tests__/errorCalculation.js
+++ b/src/__tests__/errorCalculation.js
@@ -1,10 +1,10 @@
-import errorCalculation from '../errorCalculation';
+import * as errCalc from '../errorCalculation';
 
 function sinFunction([a, b]) {
   return (t) => a * Math.sin(b * t);
 }
 
-describe('errorCalculation test', () => {
+describe('sum of residuals', () => {
   it('Simple case', () => {
     const len = 20;
     let data = {
@@ -17,7 +17,32 @@ describe('errorCalculation test', () => {
       data.y[i] = sampleFunction(i);
     }
 
-    expect(errorCalculation(data, [2, 2], sinFunction)).toBeCloseTo(0, 3);
-    expect(errorCalculation(data, [4, 4], sinFunction)).toBeCloseTo(48.7, 1);
+    expect(errCalc.sumOfResiduals(data, [2, 2], sinFunction)).toBeCloseTo(0, 5);
+    expect(errCalc.sumOfResiduals(data, [4, 4], sinFunction)).toBeCloseTo(48.7, 1);
+
+    expect(errCalc.sumOfSquaredResiduals(data, [2, 2], sinFunction)).toBeCloseTo(0, 5);
+    expect(errCalc.sumOfSquaredResiduals(data, [4, 4], sinFunction)).toBeCloseTo(165.6, 1);
+  });
+});
+
+describe('error propagation estimator', () => {
+  it('Simple case', () => {
+    const q = Math.PI / 2;
+
+    errCalc.initializeErrorPropagation(10);
+    expect(errCalc.errorPropagation(sinFunction([4, 4]), 0, 0.001)).toBeCloseTo(0.016, 5);
+    expect(errCalc.errorPropagation(sinFunction([1, 1]), q, 0.010)).toBeCloseTo(0.000, 5);
+
+    errCalc.initializeErrorPropagation(50);
+    expect(errCalc.errorPropagation(sinFunction([4, 4]), 0, 0.25)).toBeCloseTo(2.568135, 1);
+
+    errCalc.initializeErrorPropagation(100);
+    expect(errCalc.errorPropagation(sinFunction([4, 4]), 0, 0.25)).toBeCloseTo(2.568135, 2);
+
+    errCalc.initializeErrorPropagation(1000);
+    expect(errCalc.errorPropagation(sinFunction([4, 4]), 0, 0.25)).toBeCloseTo(2.568135, 4);
+
+    errCalc.initializeErrorPropagation(10000);
+    expect(errCalc.errorPropagation(sinFunction([4, 4]), 0, 0.25)).toBeCloseTo(2.568135, 6);
   });
 });

--- a/src/__tests__/test.js
+++ b/src/__tests__/test.js
@@ -21,13 +21,13 @@ describe('levenberg-marquardt test', () => {
       initialValues: [3, 3]
     };
 
-    const { parameterValues, parameterError } = levenbergMarquardt(
+    const { parameterValues, residuals } = levenbergMarquardt(
       data,
       sinFunction,
       options
     );
     expect(parameterValues).toBeDeepCloseTo([2, 2], 3);
-    expect(parameterError).toBeCloseTo(0, 2);
+    expect(residuals).toBeCloseTo(0, 2);
   });
 
   it('Exceptions', () => {
@@ -75,13 +75,13 @@ describe('levenberg-marquardt test', () => {
       maxIterations: 200
     };
 
-    let { parameterValues, parameterError } = levenbergMarquardt(
+    let { parameterValues, residuals } = levenbergMarquardt(
       data,
       sigmoidFunction,
       options
     );
     expect(parameterValues).toBeDeepCloseTo([2, 2, 2], 1);
-    expect(parameterError).toBeCloseTo(0, 1);
+    expect(residuals).toBeCloseTo(0, 1);
   });
 
   it('Sum of lorentzians example', () => {

--- a/src/errorCalculation.js
+++ b/src/errorCalculation.js
@@ -1,21 +1,164 @@
+import nd from 'norm-dist';
+
+/** @param {number} x */
+const sq = x => x * x;
+
+/** @param {...number} n */
+const isNaN = (...n) => n.some( x => Number.isNaN(x) );
+
+
 /**
- * Calculate current error
+ * Compute equiprobable ranges in normal distribution
+ * @ignore
+ * @param {number} iterations - How many evaluations (per point per step) of the fitted function to use to approximate the error propagation through it
+ */
+export function initializeErrorPropagation( iterations ) {
+  if (equiprobableStops.length === iterations) return;
+
+  const min = nd.cdf(-2.25);
+  const max = 1 - min;
+  const step = (max - min) / (iterations - 1);
+
+  for (var i = 0, x = min; i < iterations; i++, x += step) {
+    equiprobableStops[i] = nd.icdf(x);
+  }
+}
+
+/** @type {number[]} */
+const equiprobableStops = [];
+
+
+/**
+ * Estimate error propagation through a function
+ * @ignore
+ * @param {(x: number) => number} fn - The function to approximate, outside of the function domain return `NaN`
+ * @param {number} x - The error propagation will be approximate in the neighbourhood of this point
+ * @param {number} xSigma - The standard deviation of `x`
+ * @return {number} The estimated standard deviation of `fn(x)`
+ */
+export function errorPropagation(
+  fn,
+  x,
+  xSigma
+) {
+  const stopCount = equiprobableStops.length;
+
+  var slope = 0;
+  var N = 0;
+
+  var xLast = x + xSigma * equiprobableStops[0];
+  var yLast = fn(xLast);
+
+  for (var stop = 1; stop < stopCount; stop++) {
+    var xNew = x + xSigma * equiprobableStops[stop];
+    var yNew = fn(xNew);
+
+    if (!isNaN(xNew, yNew, xLast, yLast)) {
+      slope += (yNew - yLast) / (xNew - xLast);
+      N++;
+    }
+
+    xLast = xNew;
+    yLast = yNew;
+  }
+
+  const avgSlope = slope / N;
+
+  return Math.abs(avgSlope * xSigma);
+}
+
+/**
+ * Approximate errors in point location and calculate point weights
+ * @ignore
+ * @param {{x:Array<number>, y:Array<number>, xError:Array<number>|void, yError:Array<number>|void}} data - Array of points to fit in the format [x1, x2, ... ], [y1, y2, ... ]
+ * @param {Array<number>} params - Array of parameter values
+ * @param {(n: number[]) => (x: number) => number} paramFunction - Takes the parameters and returns a function with the independent variable as a parameter
+ * @return {Array<number>} Array of point weights
+ */
+export function pointWeights(
+  data,
+  params,
+  paramFunction
+) {
+  const m = data.x.length;
+
+  /** @type {Array<number>} */
+  const errs = new Array(m);
+
+  if (!data.xError) {
+
+    if (!data.yError) {
+      return errs.fill(1);
+
+    } else {
+      errs.splice(0, m, ...data.yError);
+    }
+
+  } else {
+
+    const fn = paramFunction(params);
+    var point;
+
+    for (point = 0; point < m; point++) {
+      errs[point] = errorPropagation(fn, data.x[point], data.xError[point]);
+    }
+
+    if (data.yError) {
+      for (point = 0; point < m; point++) {
+        errs[point] = Math.sqrt( sq(errs[point]) + sq(data.yError[point]) );
+      }
+    }
+  }
+
+  // Point weight is the reciprocal of its error
+  for (point = 0; point < m; point++) {
+    errs[point] = 1 / errs[point];
+  }
+
+  return errs;
+}
+
+/**
+ * Calculate the current sum of residuals
  * @ignore
  * @param {{x:Array<number>, y:Array<number>}} data - Array of points to fit in the format [x1, x2, ... ], [y1, y2, ... ]
  * @param {Array<number>} parameters - Array of current parameter values
- * @param {function} parameterizedFunction - The parameters and returns a function with the independent variable as a parameter
+ * @param {(...n: number[]) => (x: number) => number} paramFunction - The parameters and returns a function with the independent variable as a parameter
  * @return {number}
  */
-export default function errorCalculation(
+export function sumOfResiduals(
   data,
   parameters,
-  parameterizedFunction
+  paramFunction
 ) {
   var error = 0;
-  const func = parameterizedFunction(parameters);
+  const func = paramFunction(parameters);
 
   for (var i = 0; i < data.x.length; i++) {
     error += Math.abs(data.y[i] - func(data.x[i]));
+  }
+
+  return error;
+}
+
+/**
+ * Calculate the current sum of squares of residuals
+ * @ignore
+ * @param {{x:Array<number>, y:Array<number>}} data - Array of points to fit in the format [x1, x2, ... ], [y1, y2, ... ]
+ * @param {Array<number>} parameters - Array of current parameter values
+ * @param {(...n: number[]) => (x: number) => number} paramFunction - The parameters and returns a function with the independent variable as a parameter
+ * @return {number}
+ */
+export function sumOfSquaredResiduals(
+  data,
+  parameters,
+  paramFunction
+) {
+  var error = 0;
+  const func = paramFunction(parameters);
+
+  for (var i = 0; i < data.x.length; i++) {
+    error += sq(data.y[i] - func(data.x[i]));
   }
 
   return error;

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,22 @@
-import errorCalculation from './errorCalculation';
+import { initializeErrorPropagation, sumOfResiduals, sumOfSquaredResiduals } from './errorCalculation';
 import step from './step';
 
 /**
  * Curve fitting algorithm
- * @param {{x:Array<number>, y:Array<number>}} data - Array of points to fit in the format [x1, x2, ... ], [y1, y2, ... ]
+ * @param {{x:Array<number>, y:Array<number>, xError:Array<number>|void, yError:Array<number>|void}} data - Array of points to fit in the format [x1, x2, ... ], [y1, y2, ... ]
  * @param {function} parameterizedFunction - The parameters and returns a function with the independent variable as a parameter
  * @param {object} [options] - Options object
  * @param {number} [options.damping] - Levenberg-Marquardt parameter
  * @param {number} [options.gradientDifference = 10e-2] - Adjustment for decrease the damping parameter
  * @param {Array<number>} [options.initialValues] - Array of initial parameter values
  * @param {number} [options.maxIterations = 100] - Maximum of allowed iterations
- * @param {number} [options.errorTolerance = 10e-3] - Minimum uncertainty allowed for each point
- * @return {{parameterValues: Array<number>, parameterError: number, iterations: number}}
+ * @param {number} [options.errorTolerance = 0] - Minimum change of the sum of residuals per step – if the sum of residuals changes less than this number, the algorithm will stop
+ * @param {Array<number>} [options.maxValues] - Maximum values for the parameters
+ * @param {Array<number>} [options.minValues] - Minimum values for the parameters
+ * @param {{rough: number, fine: number}} [options.errorPropagation] - How many evaluations (per point per step) of the fitted function to use to approximate the error propagation through it
+ * @param {number} [options.errorPropagation.rough = 10] - Number of iterations for rough estimation
+ * @param {number} [options.errorPropagation.fine = 50] - Number of iterations for fine estimation
+ * @return {Result}
  */
 export default function levenbergMarquardt(
   data,
@@ -22,11 +27,17 @@ export default function levenbergMarquardt(
     maxIterations = 100,
     gradientDifference = 10e-2,
     damping = 0,
-    maxValue,
-    minValue,
-    errorTolerance = 10e-3,
-    initialValues
+    maxValues,
+    minValues,
+    errorTolerance = -1,
+    initialValues,
+    errorPropagation = { rough: 10, fine: 50 }
   } = options;
+
+  let {
+    roughError = 10,
+    fineError = 50
+  } = errorPropagation;
 
   if (damping <= 0) {
     throw new Error('The damping option must be a positive number');
@@ -47,10 +58,10 @@ export default function levenbergMarquardt(
 
   var parameters = initialValues || new Array(parameterizedFunction.length).fill(1);
   let parLen = parameters.length;
-  maxValue = maxValue || new Array(parLen).fill(Number.MAX_SAFE_INTEGER);
-  minValue = minValue || new Array(parLen).fill(Number.MIN_SAFE_INTEGER);
+  maxValues = maxValues || new Array(parLen).fill(Number.MAX_SAFE_INTEGER);
+  minValues = minValues || new Array(parLen).fill(Number.MIN_SAFE_INTEGER);
 
-  if (maxValue.length !== minValue.length) {
+  if (maxValues.length !== minValues.length) {
     throw new Error('coutes should has the same size');
   }
 
@@ -58,9 +69,13 @@ export default function levenbergMarquardt(
     throw new Error('initialValues must be an array');
   }
 
-  var error = errorCalculation(data, parameters, parameterizedFunction);
 
-  var converged = error <= errorTolerance;
+  initializeErrorPropagation(roughError);
+
+  var lastResiduals = 0;
+  var residuals = sumOfResiduals(data, parameters, parameterizedFunction);
+  var converged = false;
+  var fine = false;
 
   for (
     var iteration = 0;
@@ -76,17 +91,30 @@ export default function levenbergMarquardt(
     );
 
     for (let k = 0; k < parLen; k++) {
-      parameters[k] = Math.min(Math.max(minValue[k], parameters[k]), maxValue[k]);
+      parameters[k] = Math.min(Math.max(minValues[k], parameters[k]), maxValues[k]);
     }
 
-    error = errorCalculation(data, parameters, parameterizedFunction);
-    if (isNaN(error)) break;
-    converged = error <= errorTolerance;
+    lastResiduals = residuals;
+    residuals = sumOfResiduals(data, parameters, parameterizedFunction);
+    if (isNaN(residuals)) break;
+    converged = lastResiduals - residuals <= errorTolerance;
+
+    if (converged && !fine) {
+      initializeErrorPropagation(fineError);
+      converged = false;
+      fine = true;
+    }
   }
 
+  /**
+   * @typedef {Object} Result
+   * @property {Array<number>} parameterValues - The computed values of parameters
+   * @property {number} residuals - Sum of squared residuals of the final fit
+   * @property {number} iterations - Number of iterations used
+   */
   return {
     parameterValues: parameters,
-    parameterError: error,
+    residuals: sumOfSquaredResiduals(data, parameters, parameterizedFunction),
     iterations: iteration
   };
 }


### PR DESCRIPTION
This pull request resolves #17 by adding support for regression with known standard deviations of data. This can be done with the optional parameters `xError` and `yError` on the `data` object [passed to the algorithm](https://github.com/mljs/levenberg-marquardt/blob/fc79bc69423deb494fa9c3f0358203131c33c2ba/src/index.js#L6). I tried as hard as I could to maintain the good taste of the code, but I had to disable some overly restrictive eslint rules.

Furthermore I've done some minor API changes:
1) I've changed `minValue` and `maxValue` to `minValues` and `maxValues` respectively. This way they're more consistent with the `initialValues` option. I've exposed these options in jsDoc, which fixes #15.
2) Then I changed the property `parameterError` on the returned object to `residuals` which is a much better name as I describe in #18. However, that's a breaking change – this needs to be taken care of.
3) Finally I changed the behavior of `errorTolerance` which would fix #18… If it only worked. Details are described in the issue.

A few things that need to be done before merging:
- [ ] Add more tests for the new code
- [ ] Add a "legacy layer" which would avert the breaking changes
- [ ] Fix the behavior of `errorTolerance`
- [ ] Find a new name for `errorTolerance`
- [ ] Compare the weighted and non-weighted versions of this algorithm, together with some standard software on a real-life set of data