### PR TITLE
Fix Documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ let maxValues = [
 
 const options = {
   damping: 1.5,
-  initialValues,
-  minValues,
-  maxValues,
+  initialValues: initialValues,
+  minValues: minValues,
+  maxValues: maxValues,
   gradientDifference: 10e-2,
   maxIterations: 100,
   errorTolerance: 10e-3


### PR DESCRIPTION
The example given in README.md is not valid javascript - add the keys back into options..
