### PR TITLE
nguymin4/fix issue with parameterError

### DIFF
--- a/src/__tests__/curve.test.js
+++ b/src/__tests__/curve.test.js
@@ -5,6 +5,10 @@ import { levenbergMarquardt } from '..';
 
 expect.extend({ toBeDeepCloseTo, toMatchCloseTo });
 
+function sinFunction([a, b]) {
+  return (t) => a * Math.sin(b * t);
+}
+
 describe('curve', () => {
   describe('Contrived problems (clean data)', () => {
     // In these cases we test the algorithm's ability to find an , we use some pre-selected values and generate the data set and see if the algorithm can get close the the exact solution
@@ -30,9 +34,7 @@ describe('curve', () => {
       },
       {
         name: '2*sin(2*t)',
-        getFunctionFromParameters([a, f]) {
-          return (t) => a * Math.sin(f * t);
-        },
+        getFunctionFromParameters: sinFunction,
         n: 20,
         xStart: 0,
         xEnd: 19,
@@ -164,32 +166,18 @@ describe('curve', () => {
     });
 
     it('should return solution with lowest error', () => {
-       const data = {
+      const data = {
         x: [
-          0,
-          0.6283185307179586,
-          1.2566370614359172,
-          1.8849555921538759,
-          2.5132741228718345,
-          3.141592653589793,
-          3.7699111843077517,
-          4.39822971502571,
-          5.026548245743669,
-          5.654866776461628
+          0, 0.6283185307179586, 1.2566370614359172, 1.8849555921538759,
+          2.5132741228718345, 3.141592653589793, 3.7699111843077517,
+          4.39822971502571, 5.026548245743669, 5.654866776461628,
         ],
         y: [
-          0,
-          1.902113032590307,
-          1.1755705045849465,
-          -1.175570504584946,
-          -1.9021130325903073,
-          -4.898587196589413e-16,
-          1.902113032590307,
-          1.1755705045849467,
-          -1.1755705045849456,
-          -1.9021130325903075
-        ]
-      } 
+          0, 1.902113032590307, 1.1755705045849465, -1.175570504584946,
+          -1.9021130325903073, -4.898587196589413e-16, 1.902113032590307,
+          1.1755705045849467, -1.1755705045849456, -1.9021130325903075,
+        ],
+      };
       const options = {
         damping: 1.5,
         initialValues: [0.594398586701882, 0.3506424963635226],
@@ -197,15 +185,17 @@ describe('curve', () => {
         maxIterations: 100,
         errorTolerance: 1e-2,
       };
-      const sinFunction = ([a, b]) => (t) => a * Math.sin(b * t);
 
       const actual = levenbergMarquardt(data, sinFunction, options);
       const manualCalculatedError = data.x
         // @ts-expect-error number[] vs [number, number]
         .map(sinFunction(actual.parameterValues))
-        .reduce((acc, yHat, i) => acc + (data.y[i] - yHat) ** 2, 0)
-      expect(actual.parameterError).toBeCloseTo(manualCalculatedError, options.errorTolerance)
-      expect(actual.parameterError).toBeCloseTo(15.5, options.errorTolerance)
+        .reduce((acc, yHat, i) => acc + (data.y[i] - yHat) ** 2, 0);
+      expect(actual.parameterError).toBeCloseTo(
+        manualCalculatedError,
+        options.errorTolerance,
+      );
+      expect(actual.parameterError).toBeCloseTo(15.5, options.errorTolerance);
     });
   });
 

--- a/src/__tests__/curve.test.js
+++ b/src/__tests__/curve.test.js
@@ -162,6 +162,51 @@ describe('curve', () => {
         );
       });
     });
+
+    it('should return solution with lowest error', () => {
+       const data = {
+        x: [
+          0,
+          0.6283185307179586,
+          1.2566370614359172,
+          1.8849555921538759,
+          2.5132741228718345,
+          3.141592653589793,
+          3.7699111843077517,
+          4.39822971502571,
+          5.026548245743669,
+          5.654866776461628
+        ],
+        y: [
+          0,
+          1.902113032590307,
+          1.1755705045849465,
+          -1.175570504584946,
+          -1.9021130325903073,
+          -4.898587196589413e-16,
+          1.902113032590307,
+          1.1755705045849467,
+          -1.1755705045849456,
+          -1.9021130325903075
+        ]
+      } 
+      const options = {
+        damping: 1.5,
+        initialValues: [0.594398586701882, 0.3506424963635226],
+        gradientDifference: 1e-2,
+        maxIterations: 100,
+        errorTolerance: 1e-2,
+      };
+      const sinFunction = ([a, b]) => (t) => a * Math.sin(b * t);
+
+      const actual = levenbergMarquardt(data, sinFunction, options);
+      const manualCalculatedError = data.x
+        // @ts-expect-error number[] vs [number, number]
+        .map(sinFunction(actual.parameterValues))
+        .reduce((acc, yHat, i) => acc + (data.y[i] - yHat) ** 2, 0)
+      expect(actual.parameterError).toBeCloseTo(manualCalculatedError, options.errorTolerance)
+      expect(actual.parameterError).toBeCloseTo(19.6, options.errorTolerance)
+    });
   });
 
   describe('"Real-world" problems (noisy data)', () => {

--- a/src/__tests__/curve.test.js
+++ b/src/__tests__/curve.test.js
@@ -80,7 +80,7 @@ describe('curve', () => {
         n: 100,
         xStart: 0,
         xEnd: 99,
-        problemParameters: [1, 0.1, 0.3, 4, 0.15, 0.3],
+        problemParameters: [1.05, 0.1, 0.3, 4, 0.15, 0.3],
         options: {
           damping: 0.01,
           gradientDifference: [0.01, 0.0001, 0.0001, 0.01, 0.0001, 0],
@@ -205,7 +205,7 @@ describe('curve', () => {
         .map(sinFunction(actual.parameterValues))
         .reduce((acc, yHat, i) => acc + (data.y[i] - yHat) ** 2, 0)
       expect(actual.parameterError).toBeCloseTo(manualCalculatedError, options.errorTolerance)
-      expect(actual.parameterError).toBeCloseTo(19.6, options.errorTolerance)
+      expect(actual.parameterError).toBeCloseTo(15.5, options.errorTolerance)
     });
   });
 

--- a/src/__tests__/exceptions.test.js
+++ b/src/__tests__/exceptions.test.js
@@ -83,7 +83,7 @@ describe('Handling of ill-behaved functions', () => {
       7.807, -3.74, 21.119, 2.382, 4.269, 41.57, 73.401, 98.535, 97.059, 92.147,
     ],
   };
-  it('Should stop and return parameterError=NaN if function evaluates to NaN after starting', () => {
+  it('Should stop and return initialValues if function evaluates to NaN after starting', () => {
     const options = {
       damping: 0.01,
       maxIterations: 200,
@@ -93,11 +93,12 @@ describe('Handling of ill-behaved functions', () => {
       // c < 0 && d is not an integer so Math.pow(c, d) is NaN
     };
 
-    expect(levenbergMarquardt(data, fourParamEq, options)).toBeDeepCloseTo(
+    const actual = levenbergMarquardt(data, fourParamEq, options)
+    expect(actual).toBeDeepCloseTo(
       {
         iterations: 0,
-        parameterError: NaN,
-        parameterValues: [-64.298, 117.4022, -47.0851, -0.06148],
+        parameterError: 19289.706,
+        parameterValues:  [0, 100, 1, 0.1]
       },
       3,
     );

--- a/src/__tests__/exceptions.test.js
+++ b/src/__tests__/exceptions.test.js
@@ -93,12 +93,12 @@ describe('Handling of ill-behaved functions', () => {
       // c < 0 && d is not an integer so Math.pow(c, d) is NaN
     };
 
-    const actual = levenbergMarquardt(data, fourParamEq, options)
+    const actual = levenbergMarquardt(data, fourParamEq, options);
     expect(actual).toBeDeepCloseTo(
       {
         iterations: 0,
         parameterError: 19289.706,
-        parameterValues:  [0, 100, 1, 0.1]
+        parameterValues: [0, 100, 1, 0.1],
       },
       3,
     );

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,6 @@ export function levenbergMarquardt(data, parameterizedFunction, options = {}) {
     if (improvementMetric > improvementThreshold) {
       damping = Math.max(damping / dampingStepDown, 1e-7);
     } else {
-      error = previousError;
       damping = Math.min(damping * dampingStepUp, 1e7);
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,8 @@ export function levenbergMarquardt(data, parameterizedFunction, options = {}) {
     parameterizedFunction,
     weightSquare,
   );
+  let optimalError = error;
+  let optimalParameters = parameters.slice();
 
   let converged = error <= errorTolerance;
 
@@ -79,6 +81,11 @@ export function levenbergMarquardt(data, parameterizedFunction, options = {}) {
 
     if (isNaN(error)) break;
 
+    if (error < optimalError - errorTolerance) {
+      optimalError = error;
+      optimalParameters = parameters.slice();
+    }
+
     let improvementMetric =
       (previousError - error) /
       perturbations
@@ -102,8 +109,8 @@ export function levenbergMarquardt(data, parameterizedFunction, options = {}) {
   }
 
   return {
-    parameterValues: parameters,
-    parameterError: error,
+    parameterValues: optimalParameters,
+    parameterError: optimalError,
     iterations: iteration,
   };
 }


### PR DESCRIPTION
This PR aims to fix and improve two points which can be reviewed commit by commit and they're all covered with tests.

1. Currently, calculated error based on `parameterValues` is different from `parameterError`. The test case in  085b94c demonstrates this behavior.
=> This is clearly a bug, and we should fix it

2. With the same test case, we receive an error sequence similar to this:
`... 30, 24, 15.5, 17, 19, 19.6, 19.65, 19.652` (stuck around this till we reach `maxInterations`
Thus I believe we should implement checkpoint mechanism to save the last optimal solution (error = 15.5) to avoid sticking at local minimum.