### PR TITLE
chore: update documentationjs.yml

### DIFF
--- a/.github/workflows/documentationjs.yml
+++ b/.github/workflows/documentationjs.yml
@@ -4,16 +4,20 @@ on:
   workflow_dispatch:
   release:
     types: [published]
+env:
+  ENTRY_FILE: 'src/index.js'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build documentation
         uses: zakodium/documentationjs-action@v1
+        with:
+          entry: ${{ env.ENTRY_FILE }}
       - name: Deploy to GitHub pages
-        uses: JamesIves/github-pages-deploy-action@releases/v4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.BOT_TOKEN }}
           branch: gh-pages


### PR DESCRIPTION
The current `index.html` is empty because the documentation is build without the build folders `lib` or `lib-esm`.

This uses the `src/index.js` instead.

Won't be built until release though, to know if this works.

@lpatiny could be good if we can add hacktoberfest label 